### PR TITLE
Fix compilation with GCC 10

### DIFF
--- a/src/bullet.c
+++ b/src/bullet.c
@@ -22,6 +22,9 @@
 #include "timer.h"
 #include "../data/data.h"
 
+// the bullets themselves
+Tbullet bullet[MAX_BULLETS];
+
 // sets values on a bullet
 void set_bullet(Tbullet *b, int x, int y, double dx, double dy, BITMAP *bmp, int bad) {
 	b->x = x;

--- a/src/bullet.h
+++ b/src/bullet.h
@@ -40,7 +40,7 @@ typedef struct {
 #define MAX_BULLETS	64
 
 // the bullets themselves
-Tbullet bullet[MAX_BULLETS];
+extern Tbullet bullet[MAX_BULLETS];
 
 // functions
 void reset_bullets(Tbullet *b, int max);

--- a/src/edit.c
+++ b/src/edit.c
@@ -18,7 +18,6 @@
  **************************************************************/
 
 #include <allegro.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "main.h"
@@ -32,7 +31,7 @@ int edit_tile = 0;
 // path to current map
 char edit_path_and_file[1024];
 // datafile to use
-DATAFILE *data;
+extern DATAFILE *data;
 // current edit mode
 int edit_mode;
 

--- a/src/particle.c
+++ b/src/particle.c
@@ -19,8 +19,10 @@
 
 #include "particle.h"
 
+// the particles themselves
+Tparticle particle[MAX_PARTICLES];
 // pointer to datafile
-DATAFILE *data;
+extern DATAFILE *data;
 
 // set datafile to use
 void set_datafile(DATAFILE *d) {

--- a/src/particle.h
+++ b/src/particle.h
@@ -37,7 +37,7 @@ typedef struct {
 } Tparticle;
 
 // the particles themselves
-Tparticle particle[MAX_PARTICLES];
+extern Tparticle particle[MAX_PARTICLES];
 
 // functions
 void set_datafile(DATAFILE *d);

--- a/src/player.c
+++ b/src/player.c
@@ -21,6 +21,9 @@
 #include "timer.h"
 #include "../data/data.h"
 
+// the player
+Tplayer player;
+
 // draws the player depending on his state
 void draw_player(BITMAP *bmp, Tplayer *p, int x, int y) {
 	BITMAP *head, *body;

--- a/src/player.h
+++ b/src/player.h
@@ -48,8 +48,8 @@ typedef struct {
 	int stars_taken;
 } Tplayer;
 
-// the player 
-Tplayer player;
+// the player
+extern Tplayer player;
 
 // functions
 void draw_player(BITMAP *bmp, Tplayer *p, int x, int y);

--- a/src/script.c
+++ b/src/script.c
@@ -30,8 +30,10 @@
 // silly value 
 #define		NO_CHANGE	-3249587
 
+// array holding the sounds ids
+int active_sounds[MAX_SCRIPT_SOUNDS];
 // datafile to use
-DATAFILE *data;
+extern DATAFILE *data;
 // internal buffers
 BITMAP *buffer;
 BITMAP *swap_buffer;

--- a/src/script.h
+++ b/src/script.h
@@ -39,7 +39,7 @@ typedef struct {
 // max number of sounds played by the script
 #define MAX_SCRIPT_SOUNDS	16
 // array holding the sounds ids
-int active_sounds[MAX_SCRIPT_SOUNDS];
+extern int active_sounds[MAX_SCRIPT_SOUNDS];
 
 // functions
 int run_script(char *script, DATAFILE *d);

--- a/src/timer.c
+++ b/src/timer.c
@@ -20,6 +20,14 @@
 #include "allegro.h"
 #include "timer.h"
 
+// the variables used by the timers
+volatile int frame_count;
+volatile int fps;
+volatile int logic_count;
+volatile int lps;
+volatile int cycle_count;
+volatile int game_count;
+
 // keeps track of frames each second
 void fps_counter(void) {
 	fps = frame_count;

--- a/src/timer.h
+++ b/src/timer.h
@@ -21,12 +21,12 @@
 #define TIMERS_H
 
 // the variables used by the timers
-volatile int frame_count;
-volatile int fps;
-volatile int logic_count;
-volatile int lps;
-volatile int cycle_count;
-volatile int game_count;
+extern volatile int frame_count;
+extern volatile int fps;
+extern volatile int logic_count;
+extern volatile int lps;
+extern volatile int cycle_count;
+extern volatile int game_count;
 
 // functions
 int install_timers();


### PR DESCRIPTION
GCC 10 enables -fno-common by default with cause to compilation failure with multiple defined variables.